### PR TITLE
1.30 upgrade + Readme + update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder
+build-dir
+.idea

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Azure Storage Explorer Flatpak
+
+## Installation
+You'll need `flatpak-builder` to build the image.
+
+Pull the git repo and run `flatpak-builder --user --install --force-clean build-dir com.microsoft.AzureStorageExplorer.yaml` for test installation.
+
+## Support
+### KDE
+On KDE, you may need either KWallet with KDE Frameworks version >5.97 or a different secrets manager. Because of Kwallet's implementation of `org.freedesktop.secrets` [isn't supported by keytar](https://github.com/atom/node-keytar/issues/74) you may run into issues with KWallet. An easy solution is using `gnome-keyring` or KeepassXC secret service. For Kubuntu 22.04 LTS, you need to enable backports.

--- a/com.microsoft.AzureStorageExplorer.appdata.xml
+++ b/com.microsoft.AzureStorageExplorer.appdata.xml
@@ -33,6 +33,7 @@
       </screenshot>
   </screenshots>
   <releases>
+    <release version="1.30.0" date="2023-06-12"/>
     <release version="1.29.2" date="2023-05-31"/>
     <release version="1.24.2" date="2022-05-27"/>
     <release version="1.24.1" date="2022-05-12"/>

--- a/com.microsoft.AzureStorageExplorer.yaml
+++ b/com.microsoft.AzureStorageExplorer.yaml
@@ -8,10 +8,12 @@ separate-locales: false
 tags:
   - proprietary
 finish-args:
+  - "--filesystem=home"
   - "--share=ipc"
   - "--socket=x11"
   - "--socket=pulseaudio"
   - "--share=network"
+  - "--device=dri"
   - "--talk-name=org.freedesktop.secrets"
   - "--talk-name=org.gnome.SessionManager"
   - "--talk-name=com.canonical.AppMenu.Registrar"
@@ -62,9 +64,9 @@ modules:
         filename: storage-explorer.tar.gz
         only-arches:
           - x86_64
-        url: https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.29.2/StorageExplorer-linux-x64.tar.gz
-        sha256: 1e05b8adfad150c493f363c641a04b1e39cd598da04e5ae283b62e7d50391a70
-        size: 150431494
+        url: https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.30.0/StorageExplorer-linux-x64.tar.gz
+        sha256: f66a1e320414ce12ed864525ca6764466a26acd8d9a829da647741016e095891
+        size: 150628679
       - type: extra-data
         filename: dotnet.tar.gz
         only-arches:


### PR DESCRIPTION
I've done 1.30 upgrade.

`--filesystem=home` is for drag-drop support from your home directory  
`--device=dri` is for hw acceleration (as this is a glorified web browser)